### PR TITLE
Fix #9.

### DIFF
--- a/app/src/main/java/it/dhd/bcrmanager/ui/fragments/Home.java
+++ b/app/src/main/java/it/dhd/bcrmanager/ui/fragments/Home.java
@@ -950,7 +950,7 @@ public class Home extends Fragment implements ContactObserver.DataUpdateListener
         }
         FragmentManager fm = requireActivity().getSupportFragmentManager();
         DeleteDialog deleteDialog = new DeleteDialog(item, () -> {
-            if (TextUtils.equals(currentlyPlaying.getFileName(), item.getFileName())) {
+            if (currentlyPlaying != null && TextUtils.equals(currentlyPlaying.getFileName(), item.getFileName())) {
                 fileModel.setPlayingItem(null);
             }
             List<CallLogItem> items = new ArrayList<>();

--- a/app/src/main/java/it/dhd/bcrmanager/viewmodel/DataRepository.java
+++ b/app/src/main/java/it/dhd/bcrmanager/viewmodel/DataRepository.java
@@ -365,7 +365,9 @@ public class DataRepository {
                 if (recordingsList != null && recordingsList.size() != 0) {
                     // Store a List of file parsed
                     for (CallLogItem callLogItem : recordingsList) {
-                        fileNames.add(callLogItem.getFileName());
+                        if(callLogItem != null){
+                            fileNames.add(callLogItem.getFileName());
+                        }
                     }
                 }
                 String path = FileUtils.getPathFromUri(context, pickedDir.getUri());

--- a/app/src/main/java/it/dhd/bcrmanager/viewmodel/DataRepository.java
+++ b/app/src/main/java/it/dhd/bcrmanager/viewmodel/DataRepository.java
@@ -365,9 +365,7 @@ public class DataRepository {
                 if (recordingsList != null && recordingsList.size() != 0) {
                     // Store a List of file parsed
                     for (CallLogItem callLogItem : recordingsList) {
-                        if(callLogItem != null){
-                            fileNames.add(callLogItem.getFileName());
-                        }
+                        fileNames.add(callLogItem.getFileName());
                     }
                 }
                 String path = FileUtils.getPathFromUri(context, pickedDir.getUri());


### PR DESCRIPTION
Fix Crash on Delete by checking if there is a currently playing file before attempting to get its filename, avoiding referencing a null pointer.